### PR TITLE
adds handling of the "session/{sessionId}/se/file" endpoints

### DIFF
--- a/cmd/selenosis/main.go
+++ b/cmd/selenosis/main.go
@@ -92,6 +92,7 @@ func command() *cobra.Command {
 
 			router := mux.NewRouter()
 			router.HandleFunc("/wd/hub/session", app.HandleSession).Methods(http.MethodPost)
+			router.PathPrefix("/wd/hub/session/{sessionId}/se/file").HandlerFunc(selenosis.MakeFileEndpointHandler(app.HandleProxy))
 			router.PathPrefix("/wd/hub/session/{sessionId}").HandlerFunc(app.HandleProxy)
 			router.HandleFunc("/wd/hub/status", app.HandleHubStatus).Methods(http.MethodGet)
 			router.PathPrefix("/vnc/{sessionId}").Handler(websocket.Handler(app.HandleVNC()))

--- a/handlers.go
+++ b/handlers.go
@@ -231,6 +231,16 @@ func (app *App) HandleProxy(w http.ResponseWriter, r *http.Request) {
 
 }
 
+func MakeFileEndpointHandler(handle http.HandlerFunc) http.HandlerFunc {
+	suffix := "/se/file"
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			r.URL.Path = strings.TrimSuffix(r.URL.Path, suffix) + "/file"
+		}
+		handle(w, r)
+	}
+}
+
 //HandleHubStatus ...
 func (app *App) HandleHubStatus(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -569,6 +569,31 @@ func TestHandleStatus(t *testing.T) {
 
 }
 
+func TestMakeFileEndpointHandler(t *testing.T) {
+	tests := map[string]struct {
+		before string
+		after string
+	} {
+		"Test removing `/se` from path": {
+			before: "anything/se/file",
+			after: "anything/file",
+		},
+		"Test removing `/se` from path where no `se` at all": {
+			before: "anything/file",
+			after: "anything/file",
+		},
+	}
+	for name, test := range tests {
+		t.Logf("TC %s", name)
+		f := func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.Path, test.after)
+		}
+		wrapped := MakeFileEndpointHandler(f)
+		request := http.Request{URL: &url.URL{Path: test.before}}
+		wrapped(nil, &request)
+	}
+}
+
 func initApp(p *PlatformMock) *App {
 	logger := &logrus.Logger{}
 	client := NewPlatformMock(p)


### PR DESCRIPTION
Since Selenium 4.0 the standard way to upload files is to use the aforementioned endpoint. The backend drivers like geckodriver and chromedriver don't support this and this should be handled by proxy.